### PR TITLE
Make content-type test in MessageBoardPartTwo case insensitive

### DIFF
--- a/Lesson-2/4_MessageboardPartTwo/test.py
+++ b/Lesson-2/4_MessageboardPartTwo/test.py
@@ -59,7 +59,7 @@ def test_GET():
     elif r.status_code != 200:
         return ("The server returned status code {} instead of a 200 OK."
                 ).format(r.status_code)
-    elif not r.headers['content-type'].startswith('text/html'):
+    elif not r.headers['content-type'].lower().startswith('text/html'):
         return ("The server didn't return Content-type: text/html.")
     elif '<title>Message Board</title>' not in r.text:
         return ("The server didn't return the form text I expected.")

--- a/Lesson-2/5_MessageboardPartThree/test.py
+++ b/Lesson-2/5_MessageboardPartThree/test.py
@@ -60,7 +60,7 @@ def test_GET():
     elif r.status_code != 200:
         return ("The server returned status code {} instead of a 200 OK."
                 ).format(r.status_code)
-    elif not r.headers['content-type'].startswith('text/html'):
+    elif not r.headers['content-type'].lower().startswith('text/html'):
         return ("The server didn't return Content-type: text/html.")
     elif '<title>Message Board</title>' not in r.text:
         return ("The server didn't return the form text I expected.")

--- a/Lesson-2/7_BookmarkServer/test.py
+++ b/Lesson-2/7_BookmarkServer/test.py
@@ -76,7 +76,7 @@ def test_GET_root():
     elif r.status_code != 200:
         return ("The server returned status code {} instead of a 200 OK."
                 ).format(r.status_code)
-    elif not r.headers['content-type'].startswith('text/html'):
+    elif not r.headers['content-type'].lower().startswith('text/html'):
         return ("The server didn't return Content-type: text/html.")
     elif '<title>Bookmark Server</title>' not in r.text:
         return ("The server didn't return the form text I expected.")

--- a/Lesson-3/2_CookieServer/test.py
+++ b/Lesson-3/2_CookieServer/test.py
@@ -65,7 +65,7 @@ def test_GET_plain():
     elif r.status_code != 200:
         return ("The server returned status code {} instead of a 200 OK."
                 ).format(r.status_code)
-    elif not r.headers['content-type'].startswith('text/html'):
+    elif not r.headers['content-type'].lower().startswith('text/html'):
         return ("The server didn't return Content-type: text/html.")
     elif '<title>I Remember You</title>' not in r.text:
         return ("The server didn't return the form text I expected.")
@@ -93,7 +93,7 @@ def test_GET_cookie():
     elif r.status_code != 200:
         return ("The server returned status code {} instead of a 200 OK."
                 ).format(r.status_code)
-    elif not r.headers['content-type'].startswith('text/html'):
+    elif not r.headers['content-type'].lower().startswith('text/html'):
         return ("The server didn't return Content-type: text/html.")
     elif name not in r.text:
         return ("The server didn't display the name from the cookie.")


### PR DESCRIPTION
I think the test for `content-type` should be case insensitive, as the HTTP protocol states message headers are not case sensitive. Without this change, the test rejects `'text/HTML'` for example. I feel like it would be a better test if it were case insensitive?

https://stackoverflow.com/questions/7718476/are-http-headers-content-type-c-case-sensitive
https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2